### PR TITLE
Add assembly and rework dehost

### DIFF
--- a/conf/climb.config
+++ b/conf/climb.config
@@ -8,4 +8,5 @@ params {
     max_cpus                   = 16
     max_time                   = '240.h'
 
+    store_dir = "/shared/team/databases/"
 }

--- a/conf/params.config
+++ b/conf/params.config
@@ -39,6 +39,7 @@ params {
     fastq = null
 
     skip_dehosting = false
+    flye_mode = "--nano-raw"
 
     disable_ping = false
     threads = 2

--- a/conf/params.config
+++ b/conf/params.config
@@ -30,7 +30,7 @@ params {
     help = false
     version = false
 
-    store_dir = "store_dir"
+    store_dir = "${projectDir}/store_dir"
 
     climb = false
     local = false
@@ -38,7 +38,8 @@ params {
     unique_id = null
     fastq = null
 
-    skip_dehosting = false
+    skip_host_filter = false
+    hostile_database_name = "human-t2t-hla.argos-bacteria-985_rs-viral-202401_ml-phage-202401"
     flye_mode = "--nano-raw"
 
     disable_ping = false

--- a/modules/assemble.nf
+++ b/modules/assemble.nf
@@ -1,0 +1,65 @@
+process assemble {
+    label 'process_high'
+
+     container "community.wave.seqera.io/library/flye:2.9.5--d577924c8416ccd8"
+
+    input:
+    tuple val(unique_id), path(reads)
+
+    output:
+    tuple val(unique_id), path("*.fasta.gz"), emit: fasta
+    tuple val(unique_id), path("*.gfa.gz"), emit: gfa
+    tuple val(unique_id), path("*.gv.gz"), emit: gv
+    tuple val(unique_id), path("*.txt"), emit: txt
+    tuple val(unique_id), path("*.log"), emit: log
+    tuple val(unique_id), path("*.json"), emit: json
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${unique_id}"
+    def valid_mode = ["--pacbio-raw", "--pacbio-corr", "--pacbio-hifi", "--nano-raw", "--nano-corr", "--nano-hq"]
+    if (!valid_mode.contains(params.flye_mode)) {
+        error("Unrecognised mode ${params.flye_mode} to run Flye. Options: ${valid_mode.join(', ')}")
+    }
+    """
+    flye \\
+        ${params.flye_mode} \\
+        ${reads} \\
+        --out-dir . \\
+        --threads \\
+        ${task.cpus} \\
+        ${args}
+
+    gzip -c assembly.fasta > ${prefix}.assembly.fasta.gz
+    gzip -c assembly_graph.gfa > ${prefix}.assembly_graph.gfa.gz
+    gzip -c assembly_graph.gv > ${prefix}.assembly_graph.gv.gz
+    mv assembly_info.txt ${prefix}.assembly_info.txt
+    mv flye.log ${prefix}.flye.log
+    mv params.json ${prefix}.params.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        flye: \$( flye --version )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${unique_id.id}"
+    """
+    echo stub | gzip -c > ${prefix}.assembly.fasta.gz
+    echo stub | gzip -c > ${prefix}.assembly_graph.gfa.gz
+    echo stub | gzip -c > ${prefix}.assembly_graph.gv.gz
+    echo contig_1 > ${prefix}.assembly_info.txt
+    echo stub > ${prefix}.flye.log
+    echo stub > ${prefix}.params.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        flye: \$( flye --version )
+    END_VERSIONS
+    """
+}

--- a/modules/assemble.nf
+++ b/modules/assemble.nf
@@ -1,7 +1,11 @@
 process assemble {
     label 'process_high'
 
-     container "community.wave.seqera.io/library/flye:2.9.5--d577924c8416ccd8"
+    container "community.wave.seqera.io/library/flye:2.9.5--d577924c8416ccd8"
+
+    publishDir "${params.outdir}/${unique_id}/assembly/", mode: 'copy', pattern: "*.gz"
+    publishDir "${params.outdir}/${unique_id}/assembly/", mode: 'copy', pattern: "*.log"
+
 
     input:
     tuple val(unique_id), path(reads)

--- a/modules/dehost.nf
+++ b/modules/dehost.nf
@@ -21,7 +21,7 @@ process fetchHostileReference {
 
 process runHostile {
 
-    label "process_low"
+    label "process_medium"
     container "community.wave.seqera.io/library/hostile:2.0.0--a16bb8e6c792e0d0"
 
     input:

--- a/modules/dehost.nf
+++ b/modules/dehost.nf
@@ -1,21 +1,62 @@
 #!/usr/bin/env nextflow
+process fetchHostileReference {
 
-process dehost {
+    label 'process_low'
+
+    container 'community.wave.seqera.io/library/hostile:2.0.0--a16bb8e6c792e0d0'
+
+    conda 'bioconda::hostile=2.0.0'
+
+    input:
+    path store_dir
+
+    output:
+    path "hostile.ok"
+
+    script:
+    """
+    export HOSTILE_CACHE_DIR='${store_dir}/hostile'
+    hostile fetch --aligner bowtie2
+
+    touch hostile.ok
+    """
+}
+
+process runHostile {
 
     label "process_low"
     container "community.wave.seqera.io/library/hostile:2.0.0--a16bb8e6c792e0d0"
 
     input:
     tuple val(unique_id), path(fastq)
+    path hostile_ok
+
 
     output:
     tuple val(unique_id), path("${fastq.baseName}.clean.fastq")
 
     script:
     """
+    export HOSTILE_CACHE_DIR='${params.store_dir}/hostile/'
     hostile clean \
       --fastq1 ${fastq} \
       --index human-t2t-hla.argos-bacteria-985_rs-viral-202401_ml-phage-202401 \
       -o - > ${fastq.baseName}.clean.fastq
     """
+}
+
+workflow  dehost{
+    take:
+        fastq_ch
+    main:
+        if (!params.skip_host_filter) {
+            fetchHostileReference(params.store_dir)
+            runHostile(fastq_ch, fetchHostileReference.out)
+            filtered_reads_ch = runHostile.out
+
+        } else {
+            filtered_reads_ch = fastq_ch
+        }
+    emit:
+        clean = filtered_reads_ch
 }

--- a/subworkflows/miffy.nf
+++ b/subworkflows/miffy.nf
@@ -1,5 +1,5 @@
 include { dehost } from '../modules/dehost'
-
+include { assemble } from '../modules/assemble'
 
 workflow run_miffy
 {
@@ -7,6 +7,7 @@ workflow run_miffy
         fastq_ch
     main:
         dehost(fastq_ch)
+        assemble(dehost.out)
     emit:
-        dehost.out
+        assemble.out.fasta
 }


### PR DESCRIPTION
Cache the hostile index so a subsequent run doesn't download the index (NB tried with a separate download step but this version of hostile didn't like fetching this index rather than the default one and the alternative approach worked...)

Add metaflye assembly module